### PR TITLE
Change favicon to https to prevent mixed-content error

### DIFF
--- a/calaccess_website/templates/calaccess_website/base.html
+++ b/calaccess_website/templates/calaccess_website/base.html
@@ -6,7 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="google-site-verification" content="Wrn_UnGhY-K8HHXWOvf1M4QzJzMunfVw3xf53COsRqk" />
-    <link rel="icon" type="image/png" href="http://{{ CALACCESS_WEBSITE_DOMAIN }}/static/calaccess_website/images/favicon.png">
+    <link rel="icon" type="image/png" href="https://{{ CALACCESS_WEBSITE_DOMAIN }}/static/calaccess_website/images/favicon.png">
 
     <title>{% block title %}{{ CALACCESS_WEBSITE_TITLE }}{% endblock%}</title>
     <meta name="description" content="{{ CALACCESS_WEBSITE_DESCRIPTION }}">


### PR DESCRIPTION
<img width="1280" alt="screen shot 2017-09-11 at 11 20 01 am" src="https://user-images.githubusercontent.com/856628/30282393-2e59de68-96e3-11e7-89f4-24c18a508b96.png">

Fixing this error